### PR TITLE
#24 Requirements update + loadenv fixed

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,9 @@ from PIL import Image
 import time
 from datetime import datetime
 import re
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Constants
 GEMINI_API_KEY = os.getenv("GEMINI_API_KEY", "YOUR_API_KEY_HERE")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ google-generativeai
 asyncio
 streamlit
 python-dotenv
+pillow
+datetime


### PR DESCRIPTION
The datetime library should be included by default. But it maybe a error in your system. It should be fixed now. Just enter pip install -r requirements.txt again and it should be resolved.
Issue: #24 Pr: #25 