### PR TITLE
Add reset button functionality

### DIFF
--- a/app.py
+++ b/app.py
@@ -456,7 +456,14 @@ def main():
     col1, col2 = st.columns([3, 2])
 
     with col1:
+        if st.button("🔄 Reset Chat", help="Clear all chat history and start fresh"):
+            for key in ['messages', 'question_history']:
+                if key in st.session_state:
+                    st.session_state[key] = []
+            st.rerun()
+
         st.title("🕉️ Bhagavad Gita Wisdom")
+
         st.markdown("""
         Ask questions about life, dharma, and spirituality to receive guidance from the timeless wisdom of the Bhagavad Gita.
         *Personalize your experience using the options above.*


### PR DESCRIPTION
What does this PR do?
Adds a "🔄 Reset Chat" button next to the 🕉️ Bhagavad Gita Wisdom title.
Allows users to clear the chat history (messages and question_history) with a single click.
Improves user experience by making the reset action easily accessible.

issue #5 